### PR TITLE
Fix typo in input name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,4 +17,4 @@ runs:
   steps:
     - name: Setup technical challenge
       shell: bash
-      run: ${{ github.action_path }}/scripts/setup.sh "${{ inputs.template-repository }}" "${{ inputs.owner }}" "${{ inputs.github_username }}"
+      run: ${{ github.action_path }}/scripts/setup.sh "${{ inputs.template-repository }}" "${{ inputs.owner }}" "${{ inputs.github-username }}"


### PR DESCRIPTION
The input is called `github-username`, but was referenced as `github_username`